### PR TITLE
Fix bug with "missing $ inserted"

### DIFF
--- a/lib/to_latex.rb
+++ b/lib/to_latex.rb
@@ -12,7 +12,7 @@ module ToLatex
   def self.escape s
     s.gsub(LATEX_SPECIAL_CHAR) do |c|
       case c
-      when "\\" then '\backslash{}'
+      when "\\" then '\textbackslash{}'
       when "^" then '\^{}'
       when '~' then '\~{}'
       else "\\#{c}"


### PR DESCRIPTION
In LaTeX text mode it should be \textbackslash, \backslash is for math mode. Therefore, the compiler is missing a $.